### PR TITLE
Update README to list additional iOS/macOS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ void kclose(u64 kfd);
 - `puaf_method`: The method used to obtain the PUAF primitive, with the following options:
     - `puaf_physpuppet`:
         - This method exploits [CVE-2023-23536][1].
-        - Fixed in iOS 16.4 and macOS 13.3.
+        - Fixed in iOS 15.7.4, iOS 16.4, macOS 11.7.5, macOS 12.6.4, and macOS 13.3.
         - Reachable from the App Sandbox but not the WebContent sandbox.
         - $52,500 Apple Security Bounty reward.
     - `puaf_smith`:
         - This method exploits [CVE-2023-32434][2].
-        - Fixed in iOS 16.5.1 and macOS 13.4.1.
+        - Fixed in iOS 15.7.7, iOS 16.5.1, macOS 11.7.8, macOS 12.6.7, and macOS 13.4.1.
         - Reachable from the WebContent sandbox and might have been actively exploited.
     - `puaf_landa`:
         - This method exploits [CVE-2023-41974][3].
-        - Fixed in iOS 17.0 and macOS 14.0.
+        - Fixed in iOS 16.7, iOS 17.0, macOS 13.6, and macOS 14.0.
         - Reachable from the App Sandbox but not the WebContent sandbox.
         - $70,000 Apple Security Bounty reward.
 - `kread_method`: The method used to obtain the initial `kread()` primitive.


### PR DESCRIPTION
Some notes about this commit/pull request here:
- iOS 16.7/macOS 13.6 - while not listed as being patched from CVE-2023-41974 in Apple Security Notes - is believed to be patched based on testing that was done with iOS 16.7.x (and that 16.7 RC and 17.0 RC came out alongside eachother)
- This does not account for the strange addition of CVE-2023-32434 in iOS 15.8's security notes - I've opted to leave it out due to its inclusion being an overall oddity, but somebody else who wants to look into what changed in 15.8 specifically absolutely should look into it (though isn't really important for the most part due to CVE-2023-41974, which does work even in the newly released 15.8.1 RC)
- This still does not list stuff like watchOS, but imo listing stuff like that off would complicate matters more than it's worth and theredore it makes sense to leave off